### PR TITLE
Production hardening: fix on-device summary mislabeling + API hardening

### DIFF
--- a/app/Http/Controllers/Api/V1/SyncController.php
+++ b/app/Http/Controllers/Api/V1/SyncController.php
@@ -599,8 +599,8 @@ class SyncController extends Controller
                 continue;
             }
 
-            $providerKey = $this->stringValue($row, ['provider_key', 'providerKey']) ?? 'openai';
-            $providerId = LlmProvider::getIdByKey($providerKey) ?? LlmProvider::getIdByKey('openai') ?? 1;
+            $providerKey = $this->stringValue($row, ['provider_key', 'providerKey']) ?? LlmProvider::KEY_LOCAL;
+            $providerId = LlmProvider::resolveId($providerKey);
 
             $attributes = array_filter([
                 'transcript_id' => $transcript->id,

--- a/app/Http/Controllers/Api/V1/TranscriptController.php
+++ b/app/Http/Controllers/Api/V1/TranscriptController.php
@@ -38,10 +38,17 @@ class TranscriptController extends Controller
             return $this->unauthorizedResponse();
         }
 
+        // Bounded to keep the response (with eager-loaded chunks + summaries) from
+        // growing unbounded. Stays a flat array — the app parses `data` as a list.
+        // sync/pull is the cursor-paged bulk mechanism; this is just a guard.
+        $limit = (int) $request->integer('limit', 500);
+        $limit = max(1, min($limit, 500));
+
         $transcripts = Transcript::query()
             ->where('user_id', $user->id)
             ->with(['status', 'chunks', 'summaries.provider'])
             ->latest('updated_at')
+            ->limit($limit)
             ->get();
 
         return $this->successResponse(
@@ -286,8 +293,8 @@ class TranscriptController extends Controller
                 )
                 ->first();
 
-            $providerKey = $this->stringValue($item, ['provider_key', 'providerKey']) ?? 'local';
-            $providerId = $this->resolveProviderId($providerKey);
+            $providerKey = $this->stringValue($item, ['provider_key', 'providerKey']) ?? LlmProvider::KEY_LOCAL;
+            $providerId = LlmProvider::resolveId($providerKey);
 
             $attributes = array_filter([
                 'transcript_id' => $transcript->id,
@@ -313,22 +320,6 @@ class TranscriptController extends Controller
                 $summary->delete();
             }
         }
-    }
-
-    /**
-     * Resolve a Summary.provider_id from the client provider key. The client only
-     * sends 'local' or 'cloud'; 'cloud' maps to the configured default provider so
-     * swapping the remote LLM stays a config change (see config/llm.php).
-     */
-    private function resolveProviderId(string $providerKey): int
-    {
-        $key = $providerKey === 'cloud'
-            ? (string) config('llm.default_provider')
-            : $providerKey;
-
-        return LlmProvider::getIdByKey($key)
-            ?? LlmProvider::getIdByKey(LlmProvider::KEY_LOCAL)
-            ?? (int) LlmProvider::query()->value('id');
     }
 
     /**

--- a/app/Models/Lookup/LlmProvider.php
+++ b/app/Models/Lookup/LlmProvider.php
@@ -21,4 +21,22 @@ class LlmProvider extends BaseLookup
     {
         return $this->hasMany(Summary::class, 'provider_id');
     }
+
+    /**
+     * Resolve a Summary.provider_id from a client provider key. The client sends
+     * 'local' (on-device) or 'cloud'; 'cloud' maps to the configured default
+     * remote provider so swapping the remote LLM stays a config change (see
+     * config/llm.php). Unknown keys fall back to 'local' — never to an arbitrary
+     * provider — so an on-device summary is never mislabeled as a paid one.
+     */
+    public static function resolveId(string $providerKey): int
+    {
+        $key = $providerKey === 'cloud'
+            ? (string) config('llm.default_provider')
+            : $providerKey;
+
+        return static::getIdByKey($key)
+            ?? static::getIdByKey(self::KEY_LOCAL)
+            ?? (int) static::query()->value('id');
+    }
 }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,6 +2,9 @@
 
 namespace App\Providers;
 
+use Illuminate\Cache\RateLimiting\Limit;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -19,6 +22,23 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        //
+        $this->configureRateLimiting();
+    }
+
+    /**
+     * Register the named API rate limiters (see routes/api.php).
+     */
+    private function configureRateLimiting(): void
+    {
+        // Public auth endpoints: brute-force guard, keyed by IP.
+        RateLimiter::for('auth', fn (Request $request) => Limit::perMinute(
+            (int) config('voicescribe.rate_limits.auth', 10)
+        )->by($request->ip()));
+
+        // Synchronous LLM endpoints (summarization + chat): quota/abuse guard,
+        // keyed by authenticated user (falling back to IP).
+        RateLimiter::for('llm', fn (Request $request) => Limit::perMinute(
+            (int) config('voicescribe.rate_limits.llm', 20)
+        )->by($request->user()?->getAuthIdentifier() ?? $request->ip()));
     }
 }

--- a/config/voicescribe.php
+++ b/config/voicescribe.php
@@ -17,4 +17,20 @@ return [
     |
     */
     'auth_password_bypass' => (bool) env('AUTH_PASSWORD_BYPASS', false),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Rate limits (requests per minute)
+    |--------------------------------------------------------------------------
+    |
+    | Named limiters registered in AppServiceProvider and attached in
+    | routes/api.php. `auth` guards the public login/register endpoints against
+    | brute force (keyed by IP). `llm` guards the synchronous LLM endpoints
+    | (summarization + chat) against quota exhaustion/abuse (keyed by user).
+    |
+    */
+    'rate_limits' => [
+        'auth' => (int) env('RATE_LIMIT_AUTH', 10),
+        'llm' => (int) env('RATE_LIMIT_LLM', 20),
+    ],
 ];

--- a/database/migrations/2026_06_15_000001_seed_local_llm_provider.php
+++ b/database/migrations/2026_06_15_000001_seed_local_llm_provider.php
@@ -1,0 +1,43 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Seed the 'local' LLM provider.
+ *
+ * On-device summaries sync up tagged with provider_key 'local'. The earlier seed
+ * migration (2026_06_06_000003) only inserted openai/claude/gemini, so on a
+ * migrate-only deploy (no db:seed) the 'local' row is missing and
+ * LlmProvider::resolveId('local') falls back to another provider — silently
+ * mislabeling every on-device summary. On-device is the default summarization
+ * path, so this guarantees `php artisan migrate` alone leaves a correct DB.
+ *
+ * Mirrors database/seeders/LookupSeeder.php. Idempotent (updateOrInsert), so it's
+ * safe on databases that were already seeded.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        $now = now();
+
+        DB::table('llm_providers')->updateOrInsert(
+            ['key' => 'local'],
+            [
+                'name_en' => 'On-device',
+                'name_tr' => 'Cihazda',
+                'sort_order' => 0,
+                'is_active' => true,
+                'created_at' => $now,
+                'updated_at' => $now,
+            ],
+        );
+    }
+
+    public function down(): void
+    {
+        // No-op: required reference data. Removing it would re-introduce the
+        // on-device summary mislabeling bug, so a rollback leaves it in place.
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -23,8 +23,8 @@ Route::prefix('v1')->group(function () {
     // Health check (public)
     Route::get('/health', HealthController::class)->name('api.v1.health');
 
-    // Authentication (public)
-    Route::prefix('auth')->group(function () {
+    // Authentication (public) — throttled against brute force.
+    Route::prefix('auth')->middleware('throttle:auth')->group(function () {
         Route::post('/register', [AuthController::class, 'register'])->name('api.v1.auth.register');
         Route::post('/login', [AuthController::class, 'login'])->name('api.v1.auth.login');
     });
@@ -38,8 +38,9 @@ Route::prefix('v1')->group(function () {
         // Transcripts
         Route::apiResource('transcripts', TranscriptController::class);
 
-        // Summarization
+        // Summarization — throttled (synchronous LLM call, protects provider quota).
         Route::post('/transcripts/{id}/summaries', [SummarizationController::class, 'summarize'])
+            ->middleware('throttle:llm')
             ->name('api.v1.transcripts.summarize');
 
         // On-device summary model download config (URL + gated-model token)
@@ -50,7 +51,9 @@ Route::prefix('v1')->group(function () {
         Route::get('/chat/sessions', [ChatController::class, 'index'])->name('api.v1.chat.sessions');
         Route::get('/chat/sessions/{id}', [ChatController::class, 'show'])->name('api.v1.chat.session');
         Route::delete('/chat/sessions/{id}', [ChatController::class, 'destroy'])->name('api.v1.chat.session.delete');
-        Route::post('/chat/messages', [ChatController::class, 'sendMessage'])->name('api.v1.chat.send');
+        Route::post('/chat/messages', [ChatController::class, 'sendMessage'])
+            ->middleware('throttle:llm')
+            ->name('api.v1.chat.send');
 
         // Sync
         Route::prefix('sync')->group(function () {

--- a/tests/Feature/SyncSummaryProviderTest.php
+++ b/tests/Feature/SyncSummaryProviderTest.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Summary;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+/**
+ * Regression guard for the on-device summary mislabeling bug.
+ *
+ * Deliberately does NOT seed LookupSeeder: RefreshDatabase runs the data-seeding
+ * migrations only, mirroring a production `migrate`-only deploy (no `db:seed`).
+ * That is exactly the scenario where the bug lived — the 'local' provider row was
+ * absent and SyncController's fallback relabeled on-device summaries as 'openai'.
+ */
+class SyncSummaryProviderTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_local_provider_is_present_from_migrations_alone(): void
+    {
+        $this->assertDatabaseHas('llm_providers', ['key' => 'local']);
+    }
+
+    public function test_pushed_local_summary_is_labeled_local(): void
+    {
+        $user = User::factory()->create();
+        Sanctum::actingAs($user);
+
+        $this->postJson('/api/v1/sync/push', $this->payloadWithSummary('local'))->assertOk();
+
+        $summary = Summary::query()->firstOrFail();
+        $this->assertSame('local', $summary->provider->key, 'On-device summary was mislabeled.');
+    }
+
+    public function test_pushed_cloud_summary_maps_to_default_provider(): void
+    {
+        config(['llm.default_provider' => 'gemini']);
+
+        $user = User::factory()->create();
+        Sanctum::actingAs($user);
+
+        $this->postJson('/api/v1/sync/push', $this->payloadWithSummary('cloud'))->assertOk();
+
+        $summary = Summary::query()->firstOrFail();
+        $this->assertSame('gemini', $summary->provider->key);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function payloadWithSummary(string $providerKey): array
+    {
+        return [
+            'transcripts' => [[
+                'client_local_id' => 'tr-local-1',
+                'local_id' => 'tr-local-1',
+                'title' => 'Sprint Planning',
+                'duration_seconds' => 120,
+                'status_key' => 'completed',
+                'recorded_at' => '2026-06-15T10:00:00Z',
+                'updated_at' => '2026-06-15T10:02:00Z',
+            ]],
+            'summaries' => [[
+                'client_local_id' => 'sum-local-1',
+                'transcript_client_local_id' => 'tr-local-1',
+                'provider_key' => $providerKey,
+                'model' => $providerKey === 'local' ? 'local-default' : 'gemini-2.5-flash',
+                'summary_text' => 'Summary body.',
+                'updated_at' => '2026-06-15T10:02:00Z',
+            ]],
+        ];
+    }
+}


### PR DESCRIPTION
## Why

Final hardening pass before the backend's production deploy. Cross-checked every mobile API call against the backend — the contract is complete, so this is fixes + hardening, not a build-out.

## Changes

- **Fix (data correctness):** the `local` LLM provider was only in `LookupSeeder` (db:seed), not a migration. On a `migrate`-only deploy the row was absent and `SyncController` fell back to `openai`, silently mislabeling every on-device summary (the default summarization path). Added an idempotent migration that seeds `local`, and a shared `LlmProvider::resolveId()` used by both `SyncController` (was defaulting to `openai`) and `TranscriptController` so both upsert paths resolve identically.
- **Rate limiting:** `throttle:auth` on public login/register (brute force) and `throttle:llm` on the synchronous summaries + chat endpoints (provider quota), tunable via `config/voicescribe.php`.
- **Bound `/transcripts` index:** flat-array-preserving cap with optional `?limit` (was unbounded `->get()` with eager-loaded chunks+summaries).
- **Regression test:** migration-only (no `db:seed`) test asserting a pushed `provider_key: 'local'` summary is labeled `local`, and `cloud` maps to the default provider.

## Tests

`php8.3 artisan test` → 33 passed (123 assertions). Pint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)