### PR TITLE
Dokploy deploy config: production Dockerfile + trust proxy

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,14 @@
+.git
+.github
+.env
+.env.*
+!.env.example
+node_modules
+vendor
+tests
+storage/logs/*
+storage/framework/cache/*
+storage/framework/sessions/*
+storage/framework/views/*
+.phpunit.result.cache
+README.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+# Production image for the VoiceScribe Laravel API.
+# Single web container (nginx + php-fpm) — summarization/chat are synchronous and
+# cache/session/queue use the DB driver, so no queue worker is needed.
+
+# --- Composer deps (no dev) ---------------------------------------------------
+FROM composer:2 AS vendor
+WORKDIR /app
+COPY . .
+RUN composer install --no-dev --optimize-autoloader --no-interaction --prefer-dist
+
+# --- Runtime ------------------------------------------------------------------
+FROM serversideup/php:8.3-fpm-nginx
+
+# serversideup runs Laravel boot tasks automatically at container start. This is
+# how migrations run on a managed-MySQL deploy (no db:seed) — the seed migrations
+# leave the lookup/reference data (incl. the 'local' LLM provider) in place.
+ENV AUTORUN_ENABLED=true \
+    AUTORUN_LARAVEL_MIGRATION=true \
+    AUTORUN_LARAVEL_STORAGE_LINK=true \
+    AUTORUN_LARAVEL_CONFIG_CACHE=true \
+    AUTORUN_LARAVEL_ROUTE_CACHE=true \
+    AUTORUN_LARAVEL_VIEW_CACHE=true \
+    PHP_OPCACHE_ENABLE=1
+
+USER root
+COPY --chown=www-data:www-data . /var/www/html
+COPY --from=vendor --chown=www-data:www-data /app/vendor /var/www/html/vendor
+USER www-data

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -11,6 +11,11 @@ return Application::configure(basePath: dirname(__DIR__))
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware) {
+        // Behind Traefik (Dokploy): trust the proxy so the app sees the real
+        // client IP (X-Forwarded-For) — required for per-client rate limiting —
+        // and detects https from X-Forwarded-Proto so generated URLs use https.
+        $middleware->trustProxies(at: '*');
+
         $middleware->api(prepend: [
             ForceJsonResponse::class,
         ]);


### PR DESCRIPTION
Deployment infrastructure for the production Dokploy deploy (vsbackend.hursit.me).

- **Dockerfile**: composer `--no-dev` build stage + `serversideup/php:8.3-fpm-nginx` runtime. `AUTORUN_LARAVEL_MIGRATION` runs `migrate --force` on boot, so the managed-MySQL deploy self-migrates and seeds the `local` LLM provider with no manual `db:seed`. Config/route/view caches built on boot.
- **bootstrap/app.php**: `trustProxies(at: '*')` — behind Traefik the app must read `X-Forwarded-For` (per-client rate limiting) and `X-Forwarded-Proto` (https URL generation).
- **.dockerignore**: keep `.env`, `vendor`, `tests`, `.git` out of the image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)