### PR TITLE
Fix build error: keep bootstrap/cache dir with .gitignore keeper

### DIFF
--- a/bootstrap/cache/.gitignore
+++ b/bootstrap/cache/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
Follow-up to #11. Untracking the cached files left `bootstrap/cache/` empty, so a fresh clone lacks the directory and `composer install` (package:discover) / boot-time `config:cache` fail to write there. Adds the canonical `bootstrap/cache/.gitignore` keeper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)