### PR TITLE
feat(chat): SSE streaming endpoint for chat answers

### DIFF
--- a/app/Http/Controllers/Api/V1/ChatController.php
+++ b/app/Http/Controllers/Api/V1/ChatController.php
@@ -11,11 +11,13 @@ use App\Models\ChatSession;
 use App\Models\User;
 use App\Services\Chat\ChatPrompt;
 use App\Services\Chat\TranscriptRetriever;
+use App\Services\Summarization\Contracts\StreamingLlmProviderInterface;
 use App\Services\Summarization\Exceptions\SummarizationException;
 use App\Services\Summarization\LlmProviderFactory;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Str;
+use Symfony\Component\HttpFoundation\StreamedResponse;
 
 /**
  * Chat over the user's own transcriptions (RAG). Sessions + messages persist in
@@ -159,6 +161,127 @@ class ChatController extends Controller
             ],
             message: 'Message sent successfully',
         );
+    }
+
+    /**
+     * Streaming variant of {@see sendMessage()} over Server-Sent Events. Emits a
+     * `meta` event (session + user message + sources), then `delta` events as the
+     * answer is generated, then a `done` event with the persisted assistant
+     * message. Falls back to a buffered completion when the provider cannot
+     * stream, so the client always receives a complete answer.
+     */
+    public function streamMessage(SendChatMessageRequest $request): StreamedResponse
+    {
+        /** @var User $user */
+        $user = $request->user();
+        $validated = $request->validated();
+        $question = trim((string) $validated['content']);
+
+        $session = $this->resolveSession($user, $validated['session_id'] ?? null, $question);
+
+        return response()->stream(function () use ($user, $session, $question): void {
+            $send = static function (string $event, array $data): void {
+                echo "event: {$event}\n";
+                echo 'data: '.json_encode($data, JSON_UNESCAPED_UNICODE)."\n\n";
+                if (ob_get_level() > 0) {
+                    @ob_flush();
+                }
+                flush();
+            };
+
+            if ($session === null) {
+                $send('error', ['message' => 'Chat session not found.']);
+
+                return;
+            }
+
+            $userMessage = $session->messages()->create([
+                'role' => ChatMessage::ROLE_USER,
+                'content' => $question,
+            ]);
+
+            $sources = $this->retriever->retrieve($user->id, $question);
+            $history = $session->messages()
+                ->where('id', '<', $userMessage->id)
+                ->orderByDesc('id')
+                ->limit(6)
+                ->get()
+                ->reverse()
+                ->map(fn (ChatMessage $m) => ['role' => $m->role, 'content' => $m->content])
+                ->values()
+                ->all();
+
+            $sourcePayload = array_map(static fn ($s) => [
+                'transcript_id' => $s['transcript_id'],
+                'title' => $s['title'],
+                'date' => $s['date'],
+            ], $sources);
+
+            $send('meta', [
+                'session' => (new ChatSessionResource($session->loadCount('messages')))->resolve(),
+                'user_message' => (new ChatMessageResource($userMessage))->resolve(),
+                'sources' => $sourcePayload,
+            ]);
+
+            $systemPrompt = ChatPrompt::system();
+            $userPrompt = ChatPrompt::buildUserPrompt($sources, $history, $question);
+            $answer = '';
+
+            try {
+                $provider = $this->factory->make();
+                if ($provider instanceof StreamingLlmProviderInterface) {
+                    try {
+                        foreach ($provider->stream($systemPrompt, $userPrompt) as $delta) {
+                            $answer .= $delta;
+                            $send('delta', ['text' => $delta]);
+                        }
+                    } catch (\Throwable $e) {
+                        // Mid-stream failure with nothing yet emitted → fall back
+                        // to the buffered path below; otherwise surface it.
+                        if ($answer !== '') {
+                            throw $e;
+                        }
+                        report($e);
+                    }
+                }
+
+                if ($answer === '') {
+                    $answer = $provider->complete($systemPrompt, $userPrompt);
+                    if (trim($answer) !== '') {
+                        $send('delta', ['text' => $answer]);
+                    }
+                }
+            } catch (SummarizationException $e) {
+                report($e);
+                $send('error', ['message' => 'Yapay zekâ şu an yanıt veremedi. Lütfen biraz sonra tekrar deneyin.']);
+
+                return;
+            }
+
+            $answer = trim($answer);
+            if ($answer === '') {
+                $send('error', ['message' => 'Yapay zekâ boş yanıt döndürdü.']);
+
+                return;
+            }
+
+            $assistantMessage = $session->messages()->create([
+                'role' => ChatMessage::ROLE_ASSISTANT,
+                'content' => $answer,
+                'sources' => $sourcePayload,
+            ]);
+            $session->forceFill(['last_message_at' => now()])->save();
+
+            $send('done', [
+                'session' => (new ChatSessionResource($session->loadCount('messages')))->resolve(),
+                'assistant_message' => (new ChatMessageResource($assistantMessage))->resolve(),
+            ]);
+        }, 200, [
+            'Content-Type' => 'text/event-stream',
+            'Cache-Control' => 'no-cache',
+            'X-Accel-Buffering' => 'no',
+            'Connection' => 'keep-alive',
+        ]);
     }
 
     private function resolveSession(User $user, ?int $sessionId, string $question): ?ChatSession

--- a/app/Services/Summarization/Contracts/StreamingLlmProviderInterface.php
+++ b/app/Services/Summarization/Contracts/StreamingLlmProviderInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Services\Summarization\Contracts;
+
+/**
+ * Optional capability: a provider that can stream a free-form completion
+ * token-by-token. The chat controller checks `instanceof` and falls back to the
+ * buffered {@see LlmProviderInterface::complete()} when a provider does not
+ * implement this, so adding it never breaks an existing provider.
+ */
+interface StreamingLlmProviderInterface
+{
+    /**
+     * Yields answer text deltas as they are generated. [$systemPrompt] sets
+     * behavior; [$userText] is the input. Implementations should throw before
+     * yielding their first delta when generation cannot start, so the caller can
+     * cleanly fall back to a buffered completion.
+     *
+     * @return iterable<string>
+     */
+    public function stream(string $systemPrompt, string $userText): iterable;
+}

--- a/app/Services/Summarization/Providers/GeminiProvider.php
+++ b/app/Services/Summarization/Providers/GeminiProvider.php
@@ -3,6 +3,7 @@
 namespace App\Services\Summarization\Providers;
 
 use App\Services\Summarization\Contracts\LlmProviderInterface;
+use App\Services\Summarization\Contracts\StreamingLlmProviderInterface;
 use App\Services\Summarization\Exceptions\SummarizationException;
 use App\Services\Summarization\MeetingMinutesPrompt;
 use Illuminate\Support\Facades\Http;
@@ -12,7 +13,7 @@ use Throwable;
  * Google Gemini provider using the native generateContent API with structured
  * JSON output (responseMimeType + responseSchema).
  */
-class GeminiProvider implements LlmProviderInterface
+class GeminiProvider implements LlmProviderInterface, StreamingLlmProviderInterface
 {
     private ?int $lastTokenCount = null;
 
@@ -183,6 +184,94 @@ class GeminiProvider implements LlmProviderInterface
         }
 
         throw new SummarizationException("All Gemini models failed/exhausted. Last: {$lastFailure}");
+    }
+
+    /**
+     * Streams a free-form completion via Gemini's `streamGenerateContent` SSE
+     * endpoint (`alt=sse`). Rotates models on 429/5xx like {@see generate()}.
+     * Throws before the first delta when no model can start, so the caller can
+     * fall back to a buffered completion.
+     *
+     * @return iterable<string>
+     */
+    public function stream(string $systemPrompt, string $userText): iterable
+    {
+        $apiKey = (string) ($this->config['api_key'] ?? '');
+        if ($apiKey === '') {
+            throw new SummarizationException("Missing API key for provider [{$this->name}].");
+        }
+
+        $baseUrl = rtrim((string) ($this->config['base_url'] ?? 'https://generativelanguage.googleapis.com/v1beta'), '/');
+        $body = [
+            'systemInstruction' => ['parts' => [['text' => $systemPrompt]]],
+            'contents' => [
+                ['role' => 'user', 'parts' => [['text' => $userText]]],
+            ],
+            'generationConfig' => [
+                'temperature' => 0.3,
+                'maxOutputTokens' => (int) ($this->config['max_tokens'] ?? 2048),
+            ],
+        ];
+
+        $lastFailure = 'no models configured';
+        foreach ($this->models() as $model) {
+            $endpoint = "{$baseUrl}/models/{$model}:streamGenerateContent";
+
+            try {
+                $response = Http::timeout((int) config('llm.request_timeout', 60))
+                    ->withQueryParameters(['key' => $apiKey, 'alt' => 'sse'])
+                    ->withOptions(['stream' => true])
+                    ->post($endpoint, $body);
+            } catch (Throwable $e) {
+                $lastFailure = "{$model}: {$e->getMessage()}";
+
+                continue;
+            }
+
+            $status = $response->status();
+            if (! $response->successful()) {
+                $lastFailure = "{$model}: HTTP {$status}";
+                if ($status === 429 || $status >= 500) {
+                    continue;
+                }
+                throw new SummarizationException("Gemini stream returned HTTP {$status}.");
+            }
+
+            $this->lastModel = $model;
+            $stream = $response->toPsrResponse()->getBody();
+            $buffer = '';
+            $emitted = false;
+
+            while (! $stream->eof()) {
+                $buffer .= $stream->read(2048);
+
+                while (($nl = strpos($buffer, "\n")) !== false) {
+                    $line = trim(substr($buffer, 0, $nl));
+                    $buffer = substr($buffer, $nl + 1);
+
+                    if (! str_starts_with($line, 'data:')) {
+                        continue;
+                    }
+                    $payload = trim(substr($line, 5));
+                    if ($payload === '' || $payload === '[DONE]') {
+                        continue;
+                    }
+
+                    $text = data_get(json_decode($payload, true), 'candidates.0.content.parts.0.text');
+                    if (is_string($text) && $text !== '') {
+                        $emitted = true;
+                        yield $text;
+                    }
+                }
+            }
+
+            if ($emitted) {
+                return;
+            }
+            $lastFailure = "{$model}: stream produced no text";
+        }
+
+        throw new SummarizationException("All Gemini models failed to stream. Last: {$lastFailure}");
     }
 
     public function getProviderName(): string

--- a/routes/api.php
+++ b/routes/api.php
@@ -54,6 +54,11 @@ Route::prefix('v1')->group(function () {
         Route::post('/chat/messages', [ChatController::class, 'sendMessage'])
             ->middleware('throttle:llm')
             ->name('api.v1.chat.send');
+        // Streaming (SSE) variant of the above; the client falls back to the
+        // buffered endpoint when streaming isn't available.
+        Route::post('/chat/messages/stream', [ChatController::class, 'streamMessage'])
+            ->middleware('throttle:llm')
+            ->name('api.v1.chat.stream');
 
         // Sync
         Route::prefix('sync')->group(function () {


### PR DESCRIPTION
## Chat answer streaming (SSE)

Adds `POST /api/v1/chat/messages/stream` — a Server-Sent Events variant of `sendMessage` for the mobile streaming chat UI (companion mobile PR: `voicescribe-mobile#25`).

### What it does
- Emits `meta` (session + persisted user message + sources), then `delta` events as the answer is generated, then `done` with the saved assistant message (or `error`).
- New opt-in `StreamingLlmProviderInterface`; `GeminiProvider::stream()` uses `streamGenerateContent` (`alt=sse`) with the same model-rotation on 429/5xx as `generate()`.
- Falls back to the buffered `complete()` when a provider can't stream or streaming yields nothing before the first delta — the client always gets a full answer.
- Same `throttle:llm` + auth as the buffered endpoint.

### Verification
`php -l` clean on all changed files; route registered (`php artisan route:list` shows `api/v1/chat/messages/stream`). Live token-streaming needs `GEMINI_API_KEY` + a deployed runtime to verify end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
